### PR TITLE
Allow modals to get longer if neccessary and scroll if required

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -13,8 +13,13 @@ html, body {
 	text-align: right !important;
 }
 
+.modal {
+	max-height: 80%;
+	overflow-y: auto;
+}
+
 .modal-body {
-    overflow: visible;
+	max-height: 100%;
 }
 
 #page-container {


### PR DESCRIPTION
It used to just hide overflow which seems pointless...

Also, bootstraps default max-height of 400px is stupid.
