### PR TITLE
bugfix: check for null meta input element

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -104,16 +104,24 @@ $(function(){
 		if ($label.length && $input.length) {
 			$label.addClass('label-char-counter');
 
+			// no point doing stuff if it doesn't exist
+			if ($input.size() <= 0) {
+				return true;
+			}
+
 			// Add remaining characters label
 			var prefilled = $input[0].value.length,
-			remaining = limit - prefilled;
+				remaining = limit - prefilled;
+
 			$label.attr('data-char-count', remaining);
+
 			// Make label red if too many characters
 			if (remaining < 0) {
 				$label.addClass('desc-over-limit');
 			} else {
 				$label.removeClass('desc-over-limit');
 			}
+
 			// Watch when typing in box to adjust value of label
 			$input.on('keyup focus blur', function(){
 				var chars_left = limit - this.value.length;


### PR DESCRIPTION
JavaScript error was occurring in line 101 when trying to access the value property on an undefined object. I've put in check for null object as error was causing all other JavaScript after it to break.
