### PR TITLE
Auto hide alerts on page after 5 seconds

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -22,7 +22,14 @@ $(function(){
 		return !!navigator.userAgent.match(/MSIE/i);
 	});
 
+
 	//alert(navigator.userAgent);
+
+	if ($('.alert').length > 0) {
+		setTimeout(function(){
+			$('.alert').slideUp();
+		}, 5000);
+	}
 
 	// iPhone Web App Links
 	if ($('html').hasClass('appleios')) {


### PR DESCRIPTION
When alerts are added to the page for success or error message, hide them after 5 seconds.
