### PR TITLE
Remove arrow from settings in top navigation

### DIFF
--- a/less/modules/site.less
+++ b/less/modules/site.less
@@ -124,6 +124,7 @@ html {
 					}
 					&.pull-right {
 						float: right !important;
+						border-right: 0;
 					}
 					ul {
 						background: @blue;


### PR DESCRIPTION
Design point - arrow makes user think the settings menu will dropdown. Removed arrow.
