### PR TITLE
Limit width of email column in customer reports

### DIFF
--- a/less/modules/reports.less
+++ b/less/modules/reports.less
@@ -118,3 +118,11 @@
 		max-width: 200px;
 	}
 }
+
+.report-output {
+	tbody th {
+		text-align: left;
+		max-width: 200px;
+		white-space: nowrap;
+	}
+}


### PR DESCRIPTION
Add max width to report output first column and left align contents
