### PR TITLE
Enabling redirection for blank strings in IE.

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -419,8 +419,14 @@ $(function(){
 			jqXHR.responseObj = response;
 
 			if (response != null) {
-				if (response.redirect != undefined) {
-					window.location = response.redirect;
+
+				if( response.redirect != undefined && response.redirect !== false ){
+					if( response.redirect === '' || response.redirect === true ){
+						window.location.reload(true);
+					}
+					else {
+						window.location = response.redirect;
+					}
 				}
 
 				if (response.fancybox != undefined) {
@@ -432,6 +438,7 @@ $(function(){
 					generateModal(response.modal);
 					$(document).trigger('modal.ajax.admin');
 				}
+
 			}
 
 			if (! response || ! response.modal) {
@@ -443,6 +450,7 @@ $(function(){
 				textStatus: textStatus,
 				jqXHR: jqXHR
 			});
+
 		}
 	});
 


### PR DESCRIPTION
IE9 doesn't handle sending a blank string to window.location as a redirect of the current page. Fixed that issue and enabled the user to send redirect = false for no redirect, or redirect = true to just refresh.
