### PR TITLE
[bugfix-overflow-scroll-on-inner-accordion] Allowing inner carousel divs...

### DIFF
--- a/less/bootstrap/accordion.less
+++ b/less/bootstrap/accordion.less
@@ -30,4 +30,5 @@
 .accordion-inner {
   padding: 9px 15px;
   border-top: 1px solid #e5e5e5;
+  overflow: scroll;
 }


### PR DESCRIPTION
... to have scroll bars when the content overflows - Best way to deal with tables being wider than their parent container
