### PR TITLE
fix invalid less syntax from merge conflict

### DIFF
--- a/less/modules/admin.less
+++ b/less/modules/admin.less
@@ -83,6 +83,8 @@
 	background-color: #cadddd;
 	border: 1px solid @blue;
 	padding: 10px 20px;
+}
+
 .menus-menu-itemised-edit {
 	.fieldset-buttons {
 		.btn {


### PR DESCRIPTION
A merge conflict from rebasing #110 introduced a syntax error in the admin.less file.

:ledger: Propeller Communications - not chargeable :small_blue_diamond: PropShop :small_blue_diamond: 1/00INT007.003 V1.6 (PSS) Support :small_blue_diamond: Communication (Internal)
