### PR TITLE
Add ant package and builder to admin-assets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ant/less"]
+	path = ant/less
+	url = git@github.com:less/less.js.git

--- a/build.xml
+++ b/build.xml
@@ -17,9 +17,6 @@
 
 		<property name="lessc.path" value="ant/less/bin/lessc" />
 		<echo message="lessc.path:                 ${lessc.path}" />
-
-		<property name="googleClosureCompiler.path" value="ant/google-closure-compiler.20121212.r2388.jar" />
-		<echo message="googleClosureCompiler.path: ${googleClosureCompiler.path}" />
 	</target>
 
 	<target name="less" depends="init">

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<project default="default" basedir=".">
+
+	<target name="default" depends="init, less" />
+
+	<target name="init">
+		<echo>-- Initialize Variables</echo>
+
+		<property name="less.path" value="less" />
+		<echo message="less.path:                  ${less.path}" />
+
+		<property name="css.path" value="css" />
+		<echo message="css.path:                   ${css.path}" />
+
+		<echo></echo>
+		<echo>-- Tools</echo>
+
+		<property name="lessc.path" value="ant/less/bin/lessc" />
+		<echo message="lessc.path:                 ${lessc.path}" />
+
+		<property name="googleClosureCompiler.path" value="ant/google-closure-compiler.20121212.r2388.jar" />
+		<echo message="googleClosureCompiler.path: ${googleClosureCompiler.path}" />
+	</target>
+
+	<target name="less" depends="init">
+		<echo># Convert LESS to CSS (Minified using YUI Compressor)</echo>
+		<echo>${lessc.path} ${less.path}/prop.less > ${css.path}/prop.min.css --yui-compress</echo>
+
+		<exec executable="${lessc.path}" output="${css.path}/prop.min.css" failonerror="true">
+			<arg line="${less.path}/prop.less" />
+			<arg line="--yui-compress" />
+		</exec>
+	</target>
+</project>


### PR DESCRIPTION
We don't need this in every project if the CSS is always built.

Really, the standard build.xml (or the hook) should search for all build.xml files and run Ant in those folders... this would remove the need to commit the minified CSS file.

Synergist:
INT004.006