### PR TITLE
[Header] Header height needs to be more flexible, bit of JS to adjust…

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -22,8 +22,17 @@ $(function(){
 		return !!navigator.userAgent.match(/MSIE/i);
 	});
 
+	var resizeHeader = function() {
+		$('html').css({
+			paddingTop: $('header').height() + $('header.top .top__nav>.active ul').height() + $('header.top .top__nav>.active>ul .active ul').height() - 23
+		});
+	}
 
-	//alert(navigator.userAgent);
+	setTimeout(resizeHeader, 0);
+	$(window).on('resize', resizeHeader);
+
+
+	// alert(navigator.userAgent);
 
 	if ($('.alert:not(.alert-constant)').length > 0) {
 		setTimeout(function(){


### PR DESCRIPTION
Body content has hardcoded padding, header height can change on sites with loads of nav items on smaller screen;

Slightly hacky, but working fix for body padding to be dependant on header height. Stops content being overlaid with the header/nav.